### PR TITLE
improve InternetExplorer compatibility

### DIFF
--- a/m-xml.js
+++ b/m-xml.js
@@ -223,7 +223,10 @@ THE SOFTWARE.
             }
 
             if (window.ActiveXObject || "ActiveXObject" in window) {
-                target.innerHTML = transformed;
+                var node = document.createElement('div');
+                node.innerHTML = transformed;
+                target.parentNode.insertBefore(node.firstChild, target);
+                target.parentNode.removeChild(target);
             }
             else {
                 target.parentNode.replaceChild(transformed, target);

--- a/m-xml.js
+++ b/m-xml.js
@@ -59,9 +59,7 @@ THE SOFTWARE.
             return parseXMLString(source);
         }
         else {
-            var xhr = (window.ActiveXObject || "ActiveXObject" in window) ?
-                new ActiveXObject("Msxml2.XMLHTTP.3.0") :
-                new XMLHttpRequest();
+            var xhr = new XMLHttpRequest();
 
             xhr.open("GET", source, false);
             xhr.send();

--- a/m-xml.js
+++ b/m-xml.js
@@ -55,13 +55,18 @@ THE SOFTWARE.
     }
 
     function loadXML(source) {
-        var xhr = (window.ActiveXObject || "ActiveXObject" in window) ?
+        if (isXML(source)) {
+            return parseXMLString(source);
+        }
+        else {
+            var xhr = (window.ActiveXObject || "ActiveXObject" in window) ?
                 new ActiveXObject("Msxml2.XMLHTTP.3.0") :
                 new XMLHttpRequest();
 
-        xhr.open("GET", source, false);
-        xhr.send();
-        return xhr.responseXML;
+            xhr.open("GET", source, false);
+            xhr.send();
+            return xhr.responseXML;
+        }
     }
     
     function parseXMLString(xmlString) {
@@ -101,7 +106,12 @@ THE SOFTWARE.
         if (window.ActiveXObject || "ActiveXObject" in window) {
             var xsl = new ActiveXObject("MSXML2.FreeThreadedDOMDocument.6.0");
             xsl.async = false;
-            xsl.load(source);
+            if (isXML(source)) {
+                xsl.loadXML(source);
+            }
+            else {
+                xsl.load(source);
+            }
             return xsl;
         }
 
@@ -187,10 +197,8 @@ THE SOFTWARE.
         /// compatability issues automatically.
         /// </summary>
         transform: function (xmlSource, xslSource, parameters) {
-            var xml = (isXML(xmlSource)) ? parseXMLString(xmlSource) 
-                    : loadXML(xmlSource),
-                xsl = (isXML(xslSource)) ? parseXMLString(xslSource) 
-                    : loadXSL(xslSource);
+            var xml = loadXML(xmlSource),
+                xsl = loadXSL(xslSource);
 
             if (window.ActiveXObject || "ActiveXObject" in window) {
                 return getActiveXTransform(xml, xsl, parameters);

--- a/m-xml.js
+++ b/m-xml.js
@@ -63,7 +63,7 @@ THE SOFTWARE.
 
             xhr.open("GET", source, false);
             xhr.send();
-            return xhr.responseXML;
+            return xhr.responseXML || parseXMLString(xhr.responseText);
         }
     }
     

--- a/m-xml.js
+++ b/m-xml.js
@@ -223,7 +223,9 @@ THE SOFTWARE.
             if (window.ActiveXObject || "ActiveXObject" in window) {
                 var node = document.createElement('div');
                 node.innerHTML = transformed;
-                target.parentNode.insertBefore(node.firstChild, target);
+                Array.prototype.slice.call(node.childNodes, 0).forEach(function (nd) {
+                    target.parentNode.insertBefore(nd, target);
+                });
                 target.parentNode.removeChild(target);
             }
             else {


### PR DESCRIPTION
several fixes:
- Parsing string (introduced in #4) does not work with InternetExplorer for `data-xsl`
- DOM differs
- Remove `XMLHTTP` since the other part does not support IE7 and prior
- Fall back to `responseText` when `responseXML` is not somewhat available